### PR TITLE
File split and removing solc warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,112 @@
+##
+# Project-specific
+new_tokens.csv
+
+##
+# Pythonic
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# dotenv
+.env
+
+# virtualenv
+.venv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+#misc
+.pydevproject
+.project

--- a/contracts/ForkDelta.sol
+++ b/contracts/ForkDelta.sol
@@ -130,7 +130,7 @@ contract ForkDelta {
     
     tokens[tokenGet][msg.sender] = tokens[tokenGet][msg.sender].sub(amount.add(feeTakeXfer));
     tokens[tokenGet][user] = tokens[tokenGet][user].add(amount.sub(feeMakeXfer));
-    tokens[tokenGet][feeAccount] = tokens[tokenGet][feeAccount].add(feeMakeXfer.sub(feeTakeXfer));
+    tokens[tokenGet][feeAccount] = tokens[tokenGet][feeAccount].add(feeMakeXfer.add(feeTakeXfer));
     tokens[tokenGive][user] = tokens[tokenGive][user].sub(amountGive.mul(amount) / amountGet);
     tokens[tokenGive][msg.sender] = tokens[tokenGive][msg.sender].add(amountGive.mul(amount) / amountGet);
   }
@@ -157,7 +157,7 @@ contract ForkDelta {
     uint[2] memory available;
     available[0] = amountGet.sub(orderFills[user][hash]);
     available[1] = tokens[tokenGive][user].mul(amountGet) / amountGive;
-    if (available[0]<available[1]) {
+    if (available[0] < available[1]) {
       return available[0];
     } else {
       return available[1];

--- a/contracts/ForkDelta.sol
+++ b/contracts/ForkDelta.sol
@@ -132,7 +132,6 @@ contract ForkDelta {
     tokens[tokenGet][user] = tokens[tokenGet][user].add(amount.sub(feeMakeXfer));
     tokens[tokenGet][feeAccount] = tokens[tokenGet][feeAccount].add(feeMakeXfer.sub(feeTakeXfer));
     tokens[tokenGive][user] = tokens[tokenGive][user].sub(amountGive.mul(amount) / amountGet);
-    tokens[tokenGive][user] = tokens[tokenGive][user].sub(amountGive.mul(amount) / amountGet);
     tokens[tokenGive][msg.sender] = tokens[tokenGive][msg.sender].add(amountGive.mul(amount) / amountGet);
   }
 

--- a/contracts/ForkDelta.sol
+++ b/contracts/ForkDelta.sol
@@ -140,9 +140,11 @@ contract ForkDelta {
     if (!(
       tokens[tokenGet][sender] >= amount &&
       availableVolume(tokenGet, amountGet, tokenGive, amountGive, expires, nonce, user, v, r, s) >= amount
-    )) 
+      )) { 
       return false;
-    return true;
+    } else {
+      return true;
+    }
   }
 
   function availableVolume(address tokenGet, uint amountGet, address tokenGive, uint amountGive, uint expires, uint nonce, address user, uint8 v, bytes32 r, bytes32 s) public constant returns(uint) {
@@ -150,14 +152,17 @@ contract ForkDelta {
     if (!(
       (orders[user][hash] || ecrecover(keccak256("\x19Ethereum Signed Message:\n32", hash),v,r,s) == user) &&
       block.number <= expires
-    )) 
+      )) {
       return 0;
+    }
     uint[2] memory available;
     available[0] = amountGet.sub(orderFills[user][hash]);
     available[1] = tokens[tokenGive][user].mul(amountGet) / amountGive;
-    if (available[0]<available[1]) 
+    if (available[0]<available[1]) {
       return available[0];
-    return available[1];
+    } else {
+      return available[1];
+    }
   }
 
   function amountFilled(address tokenGet, uint amountGet, address tokenGive, uint amountGive, uint expires, uint nonce, address user, uint8 v, bytes32 r, bytes32 s) public constant returns(uint) {

--- a/contracts/ForkDelta.sol
+++ b/contracts/ForkDelta.sol
@@ -23,7 +23,6 @@ contract ForkDelta {
   event Deposit(address token, address user, uint amount, uint balance);
   event Withdraw(address token, address user, uint amount, uint balance);
 
-
   modifier isAdmin() {
       require(msg.sender == admin);
       _;
@@ -97,7 +96,6 @@ contract ForkDelta {
         revert();
       }
   }
-
   
   function withdrawToken(address token, uint amount) public {
     require(token!=0);
@@ -127,24 +125,23 @@ contract ForkDelta {
     ));
     tradeBalances(tokenGet, amountGet, tokenGive, amountGive, user, amount);
     orderFills[user][hash] = orderFills[user][hash].add(amount);
-    emit Trade(tokenGet, amount, tokenGive, amountGive * amount / amountGet, user, msg.sender);
+    emit Trade(tokenGet, amount, tokenGive, amountGive.mul(amount).div(amountGet), user, msg.sender);
   }
 
   function tradeBalances(address tokenGet, uint amountGet, address tokenGive, uint amountGive, address user, uint amount) private {
-    
     //trades are free until this date in UNIX timestamp
     uint feeMakeXfer = 0;
     uint feeTakeXfer = 0;
     if (now >= freeUntilDate) {
-      feeMakeXfer = amount.mul(feeMake) / (1 ether);
-      feeTakeXfer = amount.mul(feeTake) / (1 ether);
+      feeMakeXfer = amount.mul(feeMake).div(1 ether);
+      feeTakeXfer = amount.mul(feeTake).div(1 ether);
     }
     
     tokens[tokenGet][msg.sender] = tokens[tokenGet][msg.sender].sub(amount.add(feeTakeXfer));
     tokens[tokenGet][user] = tokens[tokenGet][user].add(amount.sub(feeMakeXfer));
     tokens[tokenGet][feeAccount] = tokens[tokenGet][feeAccount].add(feeMakeXfer.add(feeTakeXfer));
-    tokens[tokenGive][user] = tokens[tokenGive][user].sub(amountGive.mul(amount) / amountGet);
-    tokens[tokenGive][msg.sender] = tokens[tokenGive][msg.sender].add(amountGive.mul(amount) / amountGet);
+    tokens[tokenGive][user] = tokens[tokenGive][user].sub(amountGive.mul(amount).div(amountGet);
+    tokens[tokenGive][msg.sender] = tokens[tokenGive][msg.sender].add(amountGive.mul(amount).div(amountGet));
   }
 
   function testTrade(address tokenGet, uint amountGet, address tokenGive, uint amountGive, uint expires, uint nonce, address user, uint8 v, bytes32 r, bytes32 s, uint amount, address sender) public constant returns(bool) {
@@ -168,7 +165,7 @@ contract ForkDelta {
     }
     uint[2] memory available;
     available[0] = amountGet.sub(orderFills[user][hash]);
-    available[1] = tokens[tokenGive][user].mul(amountGet) / amountGive;
+    available[1] = tokens[tokenGive][user].mul(amountGet).div(amountGive);
     if (available[0] < available[1]) {
       return available[0];
     } else {

--- a/contracts/ForkDelta.sol
+++ b/contracts/ForkDelta.sol
@@ -71,7 +71,7 @@ contract ForkDelta {
   function withdraw(uint amount) public {
     require(tokens[0][msg.sender] >= amount);
     tokens[0][msg.sender] = tokens[0][msg.sender].sub(amount);
-    require(msg.sender.call.value(amount)());
+    msg.sender.transfer(amount)
     Withdraw(0, msg.sender, amount, tokens[0][msg.sender]);
   }
 

--- a/contracts/SafeMath.sol
+++ b/contracts/SafeMath.sol
@@ -1,0 +1,48 @@
+pragma solidity ^0.4.18;
+
+
+/**
+ * @title SafeMath
+ * @dev Math operations with safety checks that throw on error
+ */
+library SafeMath {
+
+  /**
+  * @dev Multiplies two numbers, throws on overflow.
+  */
+  function mul(uint256 a, uint256 b) internal pure returns (uint256) {
+    if (a == 0) {
+      return 0;
+    }
+    uint256 c = a * b;
+    assert(c / a == b);
+    return c;
+  }
+
+  /**
+  * @dev Integer division of two numbers, truncating the quotient.
+  */
+  function div(uint256 a, uint256 b) internal pure returns (uint256) {
+    // assert(b > 0); // Solidity automatically throws when dividing by 0
+    uint256 c = a / b;
+    // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+    return c;
+  }
+
+  /**
+  * @dev Substracts two numbers, throws on overflow (i.e. if subtrahend is greater than minuend).
+  */
+  function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+    assert(b <= a);
+    return a - b;
+  }
+
+  /**
+  * @dev Adds two numbers, throws on overflow.
+  */
+  function add(uint256 a, uint256 b) internal pure returns (uint256) {
+    uint256 c = a + b;
+    assert(c >= a);
+    return c;
+  }
+}

--- a/contracts/SafeMath.sol
+++ b/contracts/SafeMath.sol
@@ -14,7 +14,7 @@ library SafeMath {
       return 0;
     }
     uint256 c = a * b;
-    assert(c / a == b);
+    require(c / a == b);
     return c;
   }
 
@@ -22,7 +22,7 @@ library SafeMath {
   * @dev Integer division of two numbers, truncating the quotient.
   */
   function div(uint256 a, uint256 b) internal pure returns (uint256) {
-    // assert(b > 0); // Solidity automatically throws when dividing by 0
+    require(b > 0); // Solidity automatically throws when dividing by 0
     uint256 c = a / b;
     // assert(a == b * c + a % b); // There is no case in which this doesn't hold
     return c;
@@ -32,7 +32,7 @@ library SafeMath {
   * @dev Substracts two numbers, throws on overflow (i.e. if subtrahend is greater than minuend).
   */
   function sub(uint256 a, uint256 b) internal pure returns (uint256) {
-    assert(b <= a);
+    require(b <= a);
     return a - b;
   }
 
@@ -41,7 +41,7 @@ library SafeMath {
   */
   function add(uint256 a, uint256 b) internal pure returns (uint256) {
     uint256 c = a + b;
-    assert(c >= a);
+    require(c >= a);
     return c;
   }
 }

--- a/contracts/SafeMath.sol
+++ b/contracts/SafeMath.sol
@@ -1,5 +1,4 @@
-pragma solidity ^0.4.18;
-
+pragma solidity ^0.4.21;
 
 /**
  * @title SafeMath

--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -1,0 +1,38 @@
+contract Token {
+  /// @return total amount of tokens
+  function totalSupply() public constant returns (uint256 supply) {}
+
+  /// @param _owner The address from which the balance will be retrieved
+  /// @return The balance
+  function balanceOf(address _owner) public constant returns (uint256 balance) {}
+
+  /// @notice send `_value` token to `_to` from `msg.sender`
+  /// @param _to The address of the recipient
+  /// @param _value The amount of token to be transferred
+  /// @return Whether the transfer was successful or not
+  function transfer(address _to, uint256 _value) public returns (bool success) {}
+
+  /// @notice send `_value` token to `_to` from `_from` on the condition it is approved by `_from`
+  /// @param _from The address of the sender
+  /// @param _to The address of the recipient
+  /// @param _value The amount of token to be transferred
+  /// @return Whether the transfer was successful or not
+  function transferFrom(address _from, address _to, uint256 _value) public returns (bool success) {}
+
+  /// @notice `msg.sender` approves `_addr` to spend `_value` tokens
+  /// @param _spender The address of the account able to transfer the tokens
+  /// @param _value The amount of wei to be approved for transfer
+  /// @return Whether the approval was successful or not
+  function approve(address _spender, uint256 _value) public returns (bool success) {}
+
+  /// @param _owner The address of the account owning tokens
+  /// @param _spender The address of the account able to transfer the tokens
+  /// @return Amount of remaining tokens allowed to spent
+  function allowance(address _owner, address _spender) public constant returns (uint256 remaining) {}
+
+  event Transfer(address indexed _from, address indexed _to, uint256 _value);
+  event Approval(address indexed _owner, address indexed _spender, uint256 _value);
+
+  uint public decimals;
+  string public name;
+}

--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.21;
+
 contract Token {
   /// @return total amount of tokens
   function totalSupply() public constant returns (uint256 supply) {}


### PR DESCRIPTION
* Splitted contracts into separate files and contract subdirectory (as a preparation for truffle project setup)
* Updated to current SafeMath library
* Replaces call.value with transfer
* Adjusted all pragmas to current solc 0.4.21
* Added emit keyword for all event calls
* Fixed stack to deep warning by using an array
* Minor code formatting